### PR TITLE
updated to export all images

### DIFF
--- a/commands/exportImages.go
+++ b/commands/exportImages.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/fatih/color"
@@ -81,12 +80,9 @@ func iWriteFile(products []vend.Product) error {
 	// Now loop through each product object and populate the CSV.
 	for _, product := range products {
 
-		// Ignore Vend placeholder image
-		if strings.HasPrefix(*product.ImageURL, "https://secure.vendhq.com/images/placeholder") {
-			continue
-		}
+		var images = product.Images
 
-		var sku, handle, imageURL string
+		var sku, handle string
 
 		if product.SKU != nil {
 			sku = *product.SKU
@@ -94,15 +90,16 @@ func iWriteFile(products []vend.Product) error {
 		if product.Handle != nil {
 			handle = *product.Handle
 		}
-		if product.ImageURL != nil {
-			imageURL = *product.ImageURL
+
+		// This will ignore no images since the array will be empty
+		for _, image := range images {
+			var record []string
+			record = append(record, sku)
+			record = append(record, handle)
+			record = append(record, *image.URL)
+			writer.Write(record)
 		}
 
-		var record []string
-		record = append(record, sku)
-		record = append(record, handle)
-		record = append(record, imageURL)
-		writer.Write(record)
 	}
 
 	writer.Flush()


### PR DESCRIPTION
Had these types of requests before and another when I got back.  Checked to see if it would be a relatively simple change.

The images under the same product will export the same sku/handle on separate lines just like another product.
Contemplated leaving those blank under the 'main' product with the initial sku/handle but decided each line having explicit sku/handles may be better.