### PR TITLE
SegFault trying to write the sales to CSV

### DIFF
--- a/commands/exportSales.go
+++ b/commands/exportSales.go
@@ -461,7 +461,13 @@ func writeReport(file *os.File, registers []vend.Register, users []vend.User,
 		var userName string
 		for _, user := range users {
 			if sale.UserID != nil && *sale.UserID == *user.ID {
-				userName = *user.DisplayName
+				if user.DisplayName != nil {
+					userName = *user.DisplayName
+				} else if user.Username != nil {
+					userName = *user.Username
+				} else {
+					userName = ""
+				}
 				break
 			} else {
 				userName = ""


### PR DESCRIPTION
Looks like there are times where user.DisplayName could be null and crashes when writing the sales to CSV.

Adding checks and also another option to use Username instead if not null as well.  Falls back to empty string