### PR TITLE
Move anonymous code check after null check, prevent segfault

### DIFF
--- a/commands/exportCustomers.go
+++ b/commands/exportCustomers.go
@@ -116,16 +116,20 @@ func cWriteFile(customers []vend.Customer) error {
 		var id, code, firstName, lastName, email, yearToDate, balance, loyaltyBalance, note, gender, dateOfBirth, companyName, phone, mobile, fax, twitter,
 			website, doNotEmail, physicalSuburb, physicalCity, physicalPostcode, physicalState, postalSuburb, postalCity, postalState, createdAt, postalPostcode, physicalAddress1, physicalAddress2, postalAddress1, postalAddress2, postalCountryID, customField1, customField2, customField3, customField4 string
 
-		if *customer.Code == "Anonymous Customer" {
-			continue
+		// Moving before ID since the loop can continue
+		// after the anonymous code check
+		if customer.Code != nil {
+			// Moving in here to prevent seg fault
+			if *customer.Code == "Anonymous Customer" {
+				continue
+			}
+			code = *customer.Code
 		}
 
 		if customer.ID != nil {
 			id = *customer.ID
 		}
-		if customer.Code != nil {
-			code = *customer.Code
-		}
+		
 		if customer.FirstName != nil {
 			firstName = *customer.FirstName
 		}


### PR DESCRIPTION
Hi @jackharrisonsherlock,

Got a report where there seems to be times where exportcustomers fails with a segfault on the anonymous code check.

Moving the check within the null check fixes this.

Since the anonymous code would continue the loop, moved that block as the first check even before the ID check.  Considering there are usually thousands of customer records, this seems more efficient even if practically negligible.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x144fd1e]

goroutine 1 [running]:
github.com/vend/vend-cli/commands.cWriteFile(0xc006f94000, 0x1a0a9, 0x1c343, 0x0, 0x0)
	/Users/jackharrison-sherlock/downloads/vend-cli-master/commands/exportCustomers.go:119 +0xbde
github.com/vend/vend-cli/commands.getAllCustomers()
	/Users/jackharrison-sherlock/downloads/vend-cli-master/commands/exportCustomers.go:47 +0x247
github.com/vend/vend-cli/commands.glob..func4(0x1875fe0, 0xc000142740, 0x0, 0x4)
	/Users/jackharrison-sherlock/downloads/vend-cli-master/commands/exportCustomers.go:24 +0x25
github.com/spf13/cobra.(*Command).execute(0x1875fe0, 0xc000142700, 0x4, 0x4, 0x1875fe0, 0xc000142700)
	/Users/jackharrison-sherlock/downloads/vend-cli-master/vendor/github.com/spf13/cobra/command.go:854 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0x1877f60, 0x104666a, 0x183aa80, 0xc000000300)
	/Users/jackharrison-sherlock/downloads/vend-cli-master/vendor/github.com/spf13/cobra/command.go:958 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/jackharrison-sherlock/downloads/vend-cli-master/vendor/github.com/spf13/cobra/command.go:895
github.com/vend/vend-cli/commands.Execute()
	/Users/jackharrison-sherlock/downloads/vend-cli-master/commands/root.go:46 +0x31
main.main()
	/Users/jackharrison-sherlock/downloads/vend-cli-master/main.go:6 +0x25```