### PR TITLE
Add bad request check after uploading

### DIFF
--- a/commands/importImages.go
+++ b/commands/importImages.go
@@ -368,6 +368,13 @@ func UploadImage(imagePath string, product vend.ProductUpload) error {
 			}
 		}
 
+		// without this check seg faults down the line as 
+		// there is an assumption that everything is good from this point
+		if res.StatusCode > 399 {
+			fmt.Printf(color.RedString("Error uploading image with status: %s\n\n", res.Status))
+			return err
+		}
+
 		// Make sure response body is closed at end.
 		defer res.Body.Close()
 


### PR DESCRIPTION
There was a report where during an image upload, there was a seqfault 
```
Uploading image to ea18b0c5-2925-43b6-9f14-ddf3ea321840, panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1465ec4]

goroutine 1 [running]:
github.com/vend/vend-cli/commands.UploadImage(0xc000b5aa50, 0x28, 0xc0004c90b0, 0x24, 0xc000070309, 0xa, 0xc000070300, 0x9, 0xc000070313, 0x3f, ...)
	/Users/jackharrison-sherlock/downloads/vend-cli-master/commands/importImages.go:393 +0xcc4
github.com/vend/vend-cli/commands.importImages(0x205e13c17, 0x12)
	/Users/jackharrison-sherlock/downloads/vend-cli-master/commands/importImages.go:83 +0x511
github.com/vend/vend-cli/commands.glob..func11(0x1877240, 0xc00010aba0, 0x0, 0x6)
	/Users/jackharrison-sherlock/downloads/vend-cli-master/commands/importImages.go:36 +0x39
github.com/spf13/cobra.(*Command).execute(0x1877240, 0xc00010ab40, 0x6, 0x6, 0x1877240, 0xc00010ab40)
	/Users/jackharrison-sherlock/downloads/vend-cli-master/vendor/github.com/spf13/cobra/command.go:854 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0x1877f60, 0x104666a, 0x183aa80, 0xc000000300)
	/Users/jackharrison-sherlock/downloads/vend-cli-master/vendor/github.com/spf13/cobra/command.go:958 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/jackharrison-sherlock/downloads/vend-cli-master/vendor/github.com/spf13/cobra/command.go:895
github.com/vend/vend-cli/commands.Execute()
	/Users/jackharrison-sherlock/downloads/vend-cli-master/commands/root.go:46 +0x31
main.main()
	/Users/jackharrison-sherlock/downloads/vend-cli-master/main.go:6 +0x25
```

Not sure why exactly the request is a bad request (400) but the end of the function to print the position is null because `client.Do` doesn't seem to return error on bad requests? causing the crash

Adding check for all statuses > 399 should at least error 'gracefully' and continue