### PR TITLE
replace Fatal with Panic

### DIFF
--- a/commands/auditlog.go
+++ b/commands/auditlog.go
@@ -44,26 +44,30 @@ func getAuditLog() {
 	layout := "2006-01-02T15:04:05"
 	_, err := time.Parse(layout, dateFrom)
 	if err != nil {
-		log.Fatalf("incorrect date from: %v, %v", dateFrom, err)
+		log.Printf("incorrect date from: %v, %v", dateFrom, err)
+		panic(vend.Exit{1})
 	}
 
 	_, err = time.Parse(layout, dateTo)
 	if err != nil {
-		log.Fatalf("incorrect date to: %v, %v", dateTo, err)
+		log.Printf("incorrect date to: %v, %v", dateTo, err)
+		panic(vend.Exit{1})
 	}
 
 	// Get log
 	fmt.Println("\nRetrieving Audit Log from Vend...")
 	audit, err := vc.AuditLog(dateFrom, dateTo)
 	if err != nil {
-		log.Fatalf("failed retrieving audit log from Vend %v", err)
+		log.Printf("failed retrieving audit log from Vend %v", err)
+		panic(vend.Exit{1})
 	}
 
 	// Write log to CSV
 	fmt.Println("Writing log to CSV file...")
 	err = aWriteFile(audit)
 	if err != nil {
-		log.Fatalf("failed writing audit log to CSV %v", err)
+		log.Printf("failed writing audit log to CSV %v", err)
+		panic(vend.Exit{1})
 	}
 
 	fmt.Println(color.GreenString("\nFinished!\n"))

--- a/commands/deleteCustomers.go
+++ b/commands/deleteCustomers.go
@@ -41,7 +41,8 @@ func deleteCustomers() {
 	fmt.Println("\nReading CSV...")
 	ids, err := readCSV(FilePath)
 	if err != nil {
-		log.Fatalf(color.RedString("Failed to get IDs from the file: %s", FilePath))
+		log.Printf(color.RedString("Failed to get IDs from the file: %s", FilePath))
+		panic(vend.Exit{1})
 	}
 
 	// Make the requests

--- a/commands/deleteProducts.go
+++ b/commands/deleteProducts.go
@@ -41,7 +41,8 @@ func deleteProducts() {
 	fmt.Println("\nReading CSV...")
 	ids, err := readCSV(FilePath)
 	if err != nil {
-		log.Fatalf(color.RedString("Failed to get ids from the file: %s", FilePath))
+		log.Printf(color.RedString("Failed to get ids from the file: %s", FilePath))
+		panic(vend.Exit{1})
 	}
 
 	// Make the requests

--- a/commands/exportCustomers.go
+++ b/commands/exportCustomers.go
@@ -39,19 +39,22 @@ func getAllCustomers() {
 	fmt.Println("\nRetrieving Customers from Vend...")
 	customers, err := vc.Customers()
 	if err != nil {
-		log.Fatalf("Failed retrieving customers from Vend %v", err)
+		log.Printf("Failed retrieving customers from Vend %v", err)
+		panic(vend.Exit{1})
 	}
 
 	customerGroupMap, err := vc.CustomerGroups()
 	if err != nil {
-		log.Fatalf("Failed retrieving customer groups from Vend %v", err)
+		log.Printf("Failed retrieving customer groups from Vend %v", err)
+		panic(vend.Exit{1})
 	}
 
 	// Write Customers to CSV
 	fmt.Println("Writing customers to CSV file...")
 	err = cWriteFile(customers, customerGroupMap)
 	if err != nil {
-		log.Fatalf(color.RedString("Failed writing customers to CSV: %v", err))
+		log.Printf(color.RedString("Failed writing customers to CSV: %v", err))
+		panic(vend.Exit{1})
 	}
 
 	fmt.Println(color.GreenString("\nExported %v customers  🎉\n", len(customers)))

--- a/commands/exportGiftcards.go
+++ b/commands/exportGiftcards.go
@@ -39,14 +39,16 @@ func getGiftCards() {
 	fmt.Println("\nRetrieving Gift Cards from Vend...")
 	giftCards, err := vc.GiftCards()
 	if err != nil {
-		log.Fatalf(color.RedString("Failed while retrieving Gift Cards: %v", err))
+		log.Printf(color.RedString("Failed while retrieving Gift Cards: %v", err))
+		panic(vend.Exit{1})
 	}
 
 	// Write Gift Cards to CSV
 	fmt.Println("Writing Gift Cards to CSV file...")
 	err = gcWriterFile(giftCards)
 	if err != nil {
-		log.Fatalf(color.RedString("Failed while writing Gift Cards to CSV: %v", err))
+		log.Printf(color.RedString("Failed while writing Gift Cards to CSV: %v", err))
+		panic(vend.Exit{1})
 	}
 
 	fmt.Println(color.GreenString("\nExported %v Gift Cards 🎉\n", len(giftCards)))
@@ -59,7 +61,8 @@ func gcWriterFile(giftCards []vend.GiftCard) error {
 	fileName := fmt.Sprintf("%s_giftcard_export_%v.csv", DomainPrefix, time.Now().Unix())
 	file, err := os.Create(fmt.Sprintf("./%s", fileName))
 	if err != nil {
-		log.Fatalf(color.RedString("Failed to create CSV: %v", err))
+		log.Printf(color.RedString("Failed to create CSV: %v", err))
+		panic(vend.Exit{1})
 	}
 
 	// Ensure the file is closed at the end.

--- a/commands/exportImages.go
+++ b/commands/exportImages.go
@@ -39,14 +39,16 @@ func getAllImages() {
 	fmt.Println("\nRetrieving Images from Vend...")
 	images, _, err := vc.Products()
 	if err != nil {
-		log.Fatalf(color.RedString("Failed while retrieving images: %v", err))
+		log.Printf(color.RedString("Failed while retrieving images: %v", err))
+		panic(vend.Exit{1})
 	}
 
 	// Write to CSV
 	fmt.Println("Writing images to CSV file...")
 	err = iWriteFile(images)
 	if err != nil {
-		log.Fatalf(color.RedString("Failed while writing images to CSV: %v", err))
+		log.Printf(color.RedString("Failed while writing images to CSV: %v", err))
+		panic(vend.Exit{1})
 	}
 
 	fmt.Println(color.GreenString("\nFinished!\n"))
@@ -59,7 +61,8 @@ func iWriteFile(products []vend.Product) error {
 	fileName := fmt.Sprintf("%s_image_export_%v.csv", DomainPrefix, time.Now().Unix())
 	file, err := os.Create(fmt.Sprintf("./%s", fileName))
 	if err != nil {
-		log.Fatalf("Failed to create CSV: %v", err)
+		log.Printf("Failed to create CSV: %v", err)
+		panic(vend.Exit{1})
 	}
 
 	// Ensure the file is closed at the end.

--- a/commands/exportProducts.go
+++ b/commands/exportProducts.go
@@ -42,26 +42,30 @@ func getAllProducts() {
 	fmt.Println("\nRetrieving Products...")
 	products, _, err := vc.Products()
 	if err != nil {
-		log.Fatalf("Failed retrieving products from Vend %v", err)
+		log.Printf("Failed retrieving products from Vend %v", err)
+		panic(vend.Exit{1})
 	}
 	catalogStats.TotalInventory = int64(len(products))
 
 	// Get Outlets
 	outlets, outletsMap, err := vc.Outlets()
 	if err != nil {
-		log.Fatalf("Failed retrieving outlets from Vend %v", err)
+		log.Printf("Failed retrieving outlets from Vend %v", err)
+		panic(vend.Exit{1})
 	}
 
 	// Get Outlet Taxes
 	outletTaxes, err := vc.OutletTaxes()
 	if err != nil {
-		log.Fatalf("Failed retrieving outlet taxes from Vend %v", err)
+		log.Printf("Failed retrieving outlet taxes from Vend %v", err)
+		panic(vend.Exit{1})
 	}
 
 	// Get Taxes
 	_, taxMaps, err := vc.Taxes()
 	if err != nil {
-		log.Fatalf("Failed retrieving taxes from Vend %v", err)
+		log.Printf("Failed retrieving taxes from Vend %v", err)
+		panic(vend.Exit{1})
 	}
 
 	// Get Inventory
@@ -84,7 +88,8 @@ func getAllProducts() {
 	fmt.Printf("Writing products to CSV file...\n")
 	err = productsWriteFile(products, outlets, outletsMap, recordsMap, outletTaxesMap, tagsMap)
 	if err != nil {
-		log.Fatalf(color.RedString("Failed writing products to CSV: %v", err))
+		log.Printf(color.RedString("Failed writing products to CSV: %v", err))
+		panic(vend.Exit{1})
 	}
 
 	// Print happy message, and then display catalog stats

--- a/commands/exportSales.go
+++ b/commands/exportSales.go
@@ -63,20 +63,20 @@ func getAllSales() {
 	_, err := time.Parse(layout, dateFrom)
 	if err != nil {
 		fmt.Printf("incorrect date from: %v, %v", dateFrom, err)
-		os.Exit(1)
+		panic(vend.Exit{1})
 	}
 
 	_, err = time.Parse(layout, dateTo)
 	if err != nil {
 		fmt.Printf("incorrect date to: %v, %v", dateTo, err)
-		os.Exit(1)
+		panic(vend.Exit{1})
 	}
 
 	// prevent further processing by checking provided timezone to be valid
 	_, err = getUtcTime(dateTo+"T00:00:00Z", timeZone)
 	if err != nil {
 		fmt.Printf("%v\n", err)
-		os.Exit(1)
+		panic(vend.Exit{1})
 	}
 
 	// Pull data from Vend
@@ -85,7 +85,8 @@ func getAllSales() {
 	// Get outlets first to check provided outlet first before expensive sales pull
 	outlets, _, err := vc.Outlets()
 	if err != nil {
-		log.Fatalf(color.RedString("Failed to get outlets: %v", err))
+		log.Printf(color.RedString("Failed to get outlets: %v", err))
+		panic(vend.Exit{1})
 	}
 
 	// lookup outlet name by id
@@ -114,31 +115,36 @@ func getAllSales() {
 	// Get registers
 	registers, err := vc.Registers()
 	if err != nil {
-		log.Fatalf("Failed to get registers: %v", err)
+		log.Printf("Failed to get registers: %v", err)
+		panic(vend.Exit{1})
 	}
 
 	// Get users.
 	users, err := vc.Users()
 	if err != nil {
-		log.Fatalf("Failed to get users: %v", err)
+		log.Printf("Failed to get users: %v", err)
+		panic(vend.Exit{1})
 	}
 
 	// Get customers.
 	customers, err := vc.Customers()
 	if err != nil {
-		log.Fatalf("Failed to get customers: %v", err)
+		log.Printf("Failed to get customers: %v", err)
+		panic(vend.Exit{1})
 	}
 
 	// Get Customer Groups.
 	customerGroupMap, err := vc.CustomerGroups()
 	if err != nil {
-		log.Fatalf("Failed retrieving customer groups from Vend %v", err)
+		log.Printf("Failed retrieving customer groups from Vend %v", err)
+		panic(vend.Exit{1})
 	}
 
 	// Get products.
 	products, _, err := vc.Products()
 	if err != nil {
-		log.Fatalf("Failed to get products: %v", err)
+		log.Printf("Failed to get products: %v", err)
+		panic(vend.Exit{1})
 	}
 
 	fmt.Printf("\nFiltering sales by outlet and date range...\n")
@@ -163,7 +169,8 @@ func getAllSales() {
 			// Create template report to be written to.
 			file, err := createReport(vc.DomainPrefix, outlet)
 			if err != nil {
-				log.Fatalf("Failed creating template CSV: %v", err)
+				log.Printf("Failed creating template CSV: %v", err)
+				panic(vend.Exit{1})
 			}
 			defer file.Close()
 
@@ -312,7 +319,8 @@ func createReport(domainPrefix string, outlet string) (*os.File, error) {
 	fileName := fmt.Sprintf("%s_%s_sales_history_%v.csv", DomainPrefix, outlet, time.Now().Unix())
 	file, err := os.Create(fmt.Sprintf("./%s", fileName))
 	if err != nil {
-		log.Fatalf("Error creating CSV file: %s", err)
+		log.Printf("Error creating CSV file: %s", err)
+		panic(vend.Exit{1})
 	}
 
 	// Start CSV writer.

--- a/commands/exportStorecredits.go
+++ b/commands/exportStorecredits.go
@@ -39,13 +39,15 @@ func getStoreCredits() {
 	fmt.Println("\nRetrieving Store Credits from Vend...")
 	storeCredits, err := vc.StoreCredits()
 	if err != nil {
-		log.Fatalf("Failed while retrieving store credits: %v", err)
+		log.Printf("Failed while retrieving store credits: %v", err)
+		panic(vend.Exit{1})
 	}
 
 	// // Find Customer ID from Customer Code
 	// customerCode, err := getCustomerCode(storeCredits.CustomerID)
 	// if err != nil {
-	// 	log.Fatalf("Failed trying to find customer code", err)
+	// 	log.Printf("Failed trying to find customer code", err)
+
 	// }
 	// storeCredits.CustomerCode = &customerCode
 
@@ -53,7 +55,8 @@ func getStoreCredits() {
 	fmt.Println("Writing Store Credits to CSV file...")
 	err = scWriterFile(storeCredits)
 	if err != nil {
-		log.Fatalf("Failed while writing Store Credits to CSV: %v", err)
+		log.Printf("Failed while writing Store Credits to CSV: %v", err)
+		panic(vend.Exit{1})
 	}
 
 	fmt.Println(color.GreenString("\nExported %v Store Credits\n", len(storeCredits)))
@@ -66,7 +69,8 @@ func scWriterFile(sc []vend.StoreCredit) error {
 	fileName := fmt.Sprintf("%s_storecredit_export_%v.csv", DomainPrefix, time.Now().Unix())
 	file, err := os.Create(fmt.Sprintf("./%s", fileName))
 	if err != nil {
-		log.Fatalf("Failed to create CSV: %v", err)
+		log.Printf("Failed to create CSV: %v", err)
+		panic(vend.Exit{1})
 	}
 
 	// Ensure the file is closed at the end.

--- a/commands/exportSuppliers.go
+++ b/commands/exportSuppliers.go
@@ -38,14 +38,16 @@ func getAllSuppliers() {
 	fmt.Println("\nRetrieving Suppliers from Vend...")
 	suppliers, err := vc.Suppliers()
 	if err != nil {
-		log.Fatalf("Failed while retrieving Suppliers: %v", err)
+		log.Printf("Failed while retrieving Suppliers: %v", err)
+		panic(vend.Exit{1})
 	}
 
 	// Write Suppliers to CSV
 	fmt.Println("Writing Suppliers to CSV file...")
 	err = sWriteFile(suppliers)
 	if err != nil {
-		log.Fatalf("Failed while writing Suppliers to CSV: %v", err)
+		log.Printf("Failed while writing Suppliers to CSV: %v", err)
+		panic(vend.Exit{1})
 	}
 
 	fmt.Println(color.GreenString("\nFinished!\n"))
@@ -58,7 +60,8 @@ func sWriteFile(suppliers []vend.SupplierBase) error {
 	fileName := fmt.Sprintf("%s_supplier_export_%v.csv", DomainPrefix, time.Now().Unix())
 	file, err := os.Create(fmt.Sprintf("./%s", fileName))
 	if err != nil {
-		log.Fatalf("Failed while creating CSV %v", err)
+		log.Printf("Failed while creating CSV %v", err)
+		panic(vend.Exit{1})
 	}
 
 	// Ensure the file is closed at the end.

--- a/commands/exportusers.go
+++ b/commands/exportusers.go
@@ -39,14 +39,16 @@ func getAllUsers() {
 	fmt.Println("\nRetrieving Users from Vend...")
 	users, err := vc.Users()
 	if err != nil {
-		log.Fatalf("Failed retrieving Users from Vend %v", err)
+		log.Printf("Failed retrieving Users from Vend %v", err)
+		panic(vend.Exit{1})
 	}
 
 	// Write Users to CSV
 	fmt.Println("Writing Users to CSV file...")
 	err = uWriteFile(users)
 	if err != nil {
-		log.Fatalf("Failed writing Users to CSV: %v", err)
+		log.Printf("Failed writing Users to CSV: %v", err)
+		panic(vend.Exit{1})
 	}
 
 	fmt.Println(color.GreenString("\nExported %v Users\n", len(users)))

--- a/commands/importImages.go
+++ b/commands/importImages.go
@@ -55,8 +55,8 @@ func importImages(FilePath string) {
 	fmt.Println("\nReading products from CSV file...")
 	productsFromCSV, err := ReadImageCSV(FilePath)
 	if err != nil {
-		log.Fatalf("Error reading CSV file")
-
+		log.Printf("Error reading CSV file")
+		panic(vend.Exit{1})
 	}
 
 	// Get all products from Vend.
@@ -282,7 +282,7 @@ func urlGet(url string) ([]byte, error) {
 	// Doing the request.
 	res, err := client.Get(url)
 	if err != nil {
-		log.Fatalf("Error performing request")
+		log.Printf("Error performing request")
 		return nil, err
 	}
 	// Make sure response body is closed at end.
@@ -341,8 +341,8 @@ func UploadImage(imagePath string, product vend.ProductUpload) error {
 		// Copying image binary to form file.
 		_, err = io.Copy(part, file)
 		if err != nil {
-			log.Fatalf("Error copying file for requst body: %s", err)
-			return err
+			log.Printf("Error copying file for requst body: %s", err)
+			panic(vend.Exit{1})
 		}
 
 		err = writer.Close()
@@ -407,7 +407,7 @@ func UploadImage(imagePath string, product vend.ProductUpload) error {
 		err = json.Unmarshal(resBody, &response)
 		if err != nil {
 			fmt.Println("error sourcing image - please check the image URL. Image links must be a direct link to the image.")
-			os.Exit(1)
+			panic(vend.Exit{1})
 			return err
 		}
 

--- a/commands/importProductCodes.go
+++ b/commands/importProductCodes.go
@@ -67,13 +67,15 @@ func importProductCodes() {
 	fmt.Println("Reading product codes CSV...")
 	productCodes, err := readProductCodesCSV(FilePath)
 	if err != nil {
-		log.Fatalf("Couldnt read Product Code CSV file, %s", err)
+		log.Printf("Couldnt read Product Code CSV file, %s", err)
+		panic(vend.Exit{1})
 	}
 
 	// Post Product Codes to Vend
 	err = postProductCodes(productCodes)
 	if err != nil {
-		log.Fatalf("Failed to post product codes, %s", err)
+		log.Printf("Failed to post product codes, %s", err)
+		panic(vend.Exit{1})
 	}
 
 	fmt.Println(color.GreenString("\nFinished!\n"))

--- a/commands/importSuppliers.go
+++ b/commands/importSuppliers.go
@@ -44,13 +44,15 @@ func importSuppliers() {
 	fmt.Println("\nReading Supplier CSV...")
 	suppliers, err := readSupplierCSV(FilePath)
 	if err != nil {
-		log.Fatalf("Couldnt read Supplier CSV file, %s", err)
+		log.Printf("Couldnt read Supplier CSV file, %s", err)
+		panic(vend.Exit{1})
 	}
 
 	// Post Suppliers to Vend
 	err = postSuppliers(suppliers)
 	if err != nil {
-		log.Fatalf("Failed to post Suppliers, %s", err)
+		log.Printf("Failed to post Suppliers, %s", err)
+		panic(vend.Exit{1})
 	}
 
 	fmt.Println(color.GreenString("\nFinished!\n"))
@@ -85,8 +87,10 @@ func readSupplierCSV(filePath string) ([]vend.SupplierBase, error) {
 	for i := range headerRow {
 		if headerRow[i] != headers[i] {
 			fmt.Println("Found error in header rows.")
-			log.Fatalf("No header match for: %s Instead got: %s.",
+			log.Printf("No header match for: %s Instead got: %s.",
 				string(headers[i]), string(headerRow[i]))
+			panic(vend.Exit{1})
+
 		}
 	}
 

--- a/commands/loyaltyAdjustment.go
+++ b/commands/loyaltyAdjustment.go
@@ -44,7 +44,8 @@ func loyaltyAdjustment() {
 	fmt.Println("\nReading Loyalty Adjustment CSV...")
 	loyaltyAdjustments, err := readLoyaltyAdjustmentCSV(FilePath)
 	if err != nil {
-		log.Fatalf("Couldnt read Loyalty Adjustment CSV file,  %s", err)
+		log.Printf("Couldnt read Loyalty Adjustment CSV file,  %s", err)
+		panic(vend.Exit{1})
 	}
 
 	// Posting Adjustments to Vend
@@ -90,8 +91,10 @@ func readLoyaltyAdjustmentCSV(filePath string) ([]vend.Customer, error) {
 	for i := range headerRow {
 		if headerRow[i] != headers[i] {
 			fmt.Println("Found error in header rows.")
-			log.Fatalf("No header match for: %s Instead got: %s.",
+			log.Printf("No header match for: %s Instead got: %s.",
 				string(headers[i]), string(headerRow[i]))
+			panic(vend.Exit{1})
+
 		}
 	}
 

--- a/commands/root.go
+++ b/commands/root.go
@@ -48,7 +48,7 @@ func init() {
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
-		os.Exit(1)
+		panic(vend.Exit{1})
 	}
 }
 
@@ -62,7 +62,7 @@ func initConfig() {
 		home, err := homedir.Dir()
 		if err != nil {
 			fmt.Println(err)
-			os.Exit(1)
+			panic(vend.Exit{1})
 		}
 
 		// Search config in home directory with name ".vend" (without extension).

--- a/commands/updateSaleID.go
+++ b/commands/updateSaleID.go
@@ -64,7 +64,8 @@ func updateSaleID() {
 	logFileName := fmt.Sprintf("%s_post_in_case_of_emergency_%v.txt", DomainPrefix, time.Now().Unix())
 	logFile, err := os.OpenFile(fmt.Sprintf("./%s", logFileName), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
-		log.Fatal(err)
+		log.Printf(err)
+		panic(vend.Exit{1})
 	}
 	log.SetOutput(logFile)
 

--- a/commands/updateStorecredit.go
+++ b/commands/updateStorecredit.go
@@ -74,7 +74,8 @@ func updateStoreCredit() {
 	// Test mode option is set correctly
 	submitMode = strings.ToLower(submitMode)
 	if !(submitMode == "adjust" || submitMode == "replace") {
-		log.Fatalf("'%s' is not a valid option for -m mode. Mode should be 'adjust' or replace'", submitMode)
+		log.Printf("'%s' is not a valid option for -m mode. Mode should be 'adjust' or replace'", submitMode)
+		panic(vend.Exit{1})
 	}
 
 	// Create new Vend Client.
@@ -86,7 +87,8 @@ func updateStoreCredit() {
 	fmt.Println("\nReading Store Credits CSV...")
 	csvRows, usesCustomerCodes, err := readStoreCreditCSV(FilePath, submitMode)
 	if err != nil {
-		log.Fatalf(color.RedString("Couldnt read Store Credits CSV file,  %s", err))
+		log.Printf(color.RedString("Couldnt read Store Credits CSV file,  %s", err))
+		panic(vend.Exit{1})
 	}
 
 	// if there are submitted customer_codes, convert them to customer_id
@@ -94,7 +96,8 @@ func updateStoreCredit() {
 		fmt.Println("CSV contains customer codes, setting customer ids..")
 		csvRows, err = getCustomerIDs(vc, csvRows)
 		if err != nil {
-			log.Fatalf("not able to map customer ids to codes", err)
+			log.Printf("not able to map customer ids to codes", err)
+			panic(vend.Exit{1})
 		}
 	}
 
@@ -129,7 +132,8 @@ func readStoreCreditCSV(filePath string, submitMode string) ([]vend.StoreCreditC
 	// Open our provided CSV file
 	file, err := os.Open(filePath)
 	if err != nil {
-		log.Fatalf("Could not read from CSV file\n", err)
+		log.Printf("Could not read from CSV file\n", err)
+		panic(vend.Exit{1})
 	}
 	// Make sure to close at end
 	defer file.Close()
@@ -140,7 +144,8 @@ func readStoreCreditCSV(filePath string, submitMode string) ([]vend.StoreCreditC
 	// Read and store our header line.
 	headerRow, err := reader.Read()
 	if err != nil {
-		log.Fatal("Error reading header row")
+		log.Printf("Error reading header row")
+		panic(vend.Exit{1})
 	}
 
 	// Check each header in the row is same as our template. Fail if not
@@ -149,7 +154,8 @@ func readStoreCreditCSV(filePath string, submitMode string) ([]vend.StoreCreditC
 	// Read the rest of the data from the CSV
 	rawData, err := reader.ReadAll()
 	if err != nil {
-		log.Fatal("Error reading data from csv", err)
+		log.Printf("Error reading data from csv", err)
+		panic(vend.Exit{1})
 	}
 
 	var csvStructs []vend.StoreCreditCsv
@@ -217,7 +223,8 @@ func getPrimaryAdmin(vc vend.Client) string {
 	// Get Users.
 	users, err := vc.Users()
 	if err != nil {
-		log.Fatalf("Failed retrieving Users from Vend %v", err)
+		log.Printf("Failed retrieving Users from Vend %v", err)
+		panic(vend.Exit{1})
 	}
 
 	var primaryAdmin string
@@ -243,8 +250,9 @@ func checkHeaders(submitMode string, headerRow []string) {
 	for i := range headerRow {
 		if headerRow[i] != headers[i] {
 			fmt.Println(color.RedString("Found error in header rows."))
-			log.Fatalf("\n\n 🛑 Looks like we have a mismatch in headers, this mode (%s) needs three headers: customer_id, customer_code, %s \n No header match for: %s instead got: %s \n\n",
+			log.Printf("\n\n 🛑 Looks like we have a mismatch in headers, this mode (%s) needs three headers: customer_id, customer_code, %s \n No header match for: %s instead got: %s \n\n",
 				submitMode, string(headers[2]), string(headers[i]), string(headerRow[i]))
+			panic(vend.Exit{1})
 		}
 	}
 
@@ -256,7 +264,8 @@ func getCustomerIDs(vc vend.Client, csvRows []vend.StoreCreditCsv) ([]vend.Store
 	// Get Customers
 	customers, err := vc.Customers()
 	if err != nil {
-		log.Fatalf("Failed retrieving customers from Vend %v", err)
+		log.Printf("Failed retrieving customers from Vend %v", err)
+		panic(vend.Exit{1})
 	}
 
 	// Build Customer Map
@@ -291,7 +300,8 @@ func updateAmounts(vc vend.Client, csvRows []vend.StoreCreditCsv) error {
 	// get current balances
 	storeCredits, err := vc.StoreCredits()
 	if err != nil {
-		log.Fatalf("Failed while retrieving store credits: %v", err)
+		log.Printf("Failed while retrieving store credits: %v", err)
+		panic(vend.Exit{1})
 	}
 
 	// make customer id -> customer balance map

--- a/commands/voidGiftcards.go
+++ b/commands/voidGiftcards.go
@@ -45,7 +45,8 @@ func voidGiftCards() {
 	fmt.Printf("\nReading Gift Card CSV\n")
 	ids, err := readGiftCardCSV(FilePath)
 	if err != nil {
-		log.Fatalf("Failed to get gift card numbers from the file: %s", FilePath)
+		log.Printf("Failed to get gift card numbers from the file: %s", FilePath)
+		panic(vend.Exit{1})
 	}
 
 	// Voiding Gift Cards
@@ -81,8 +82,9 @@ func readGiftCardCSV(FilePath string) ([]string, error) {
 	for i := range headerRow {
 		if headerRow[i] != headers[i] {
 			fmt.Println("Found error in header rows.")
-			log.Fatalf("No header match for: %s Instead got: %s.",
+			log.Printf("No header match for: %s Instead got: %s.",
 				string(headers[i]), string(headerRow[i]))
+			panic(vend.Exit{1})
 		}
 	}
 

--- a/commands/voidSales.go
+++ b/commands/voidSales.go
@@ -42,7 +42,8 @@ func voidSales() {
 	fmt.Printf("\nReading CSV...\n")
 	ids, err := readCSV(FilePath)
 	if err != nil {
-		log.Fatalf(color.RedString("Failed to get ids from the file: %s", FilePath))
+		log.Printf(color.RedString("Failed to get ids from the file: %s", FilePath))
+		panic(vend.Exit{1})
 	}
 
 	// Get sale payload

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.3.0
-	github.com/vend/govend v0.0.0-20230102233450-7aa1871d7b9c
+	github.com/vend/govend v0.0.0-20230519205635-fdd70a9b4568
 	github.com/wallclockbuilder/stringutil v0.0.0-20151229105100-650d35b119a3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/vend/govend v0.0.0-20230102233450-7aa1871d7b9c h1:e2LMgFkQAswqeTPVX/elXEjQ7LzqMqic0T58B05I6Ok=
-github.com/vend/govend v0.0.0-20230102233450-7aa1871d7b9c/go.mod h1:aQ2GJpu83dBAhnWesMXy9cxW7TOWcHgMAu/PQ33CPv4=
+github.com/vend/govend v0.0.0-20230519205635-fdd70a9b4568 h1:eY9/Yn8pbZN0paF3yNh0wxegJA4tUC+prrfB+2ZC43E=
+github.com/vend/govend v0.0.0-20230519205635-fdd70a9b4568/go.mod h1:aQ2GJpu83dBAhnWesMXy9cxW7TOWcHgMAu/PQ33CPv4=
 github.com/wallclockbuilder/stringutil v0.0.0-20151229105100-650d35b119a3 h1:nxWV9UNdGHW3OezVTq99ak99RvqMM+H+oG+aKNraxT4=
 github.com/wallclockbuilder/stringutil v0.0.0-20151229105100-650d35b119a3/go.mod h1:P0XJ0/hGOuePFbpFCHyzHMls2afcv32GHlmL/VuIpHg=
 github.com/wallclockbuilder/testify v0.0.0-20150512124233-dab07ac62d49 h1:2q+dCr8jqV705ORsqrqTATbsXAUQbYr6iSnPY7EVzWY=

--- a/main.go
+++ b/main.go
@@ -1,7 +1,11 @@
 package main
 
-import cmd "github.com/vend/vend-cli/commands"
+import (
+	"github.com/vend/govend/vend"
+	cmd "github.com/vend/vend-cli/commands"
+)
 
 func main() {
+	defer vend.SupressStackTrace()
 	cmd.Execute()
 }

--- a/vendor/github.com/vend/govend/vend/sale.go
+++ b/vendor/github.com/vend/govend/vend/sale.go
@@ -107,6 +107,12 @@ type Version struct {
 	Min int64 `json:"min"`
 }
 
+type erroredSalesSummary struct {
+	totalSales     int
+	oldestSaleDate string
+	oldestSaleTime time.Time
+}
+
 // Sales grabs all-time sales - version after 0
 func (c *Client) Sales() ([]Sale, error) {
 	return salesAfterVersion(0, c)
@@ -171,7 +177,8 @@ func (c *Client) GetStartVersion(dateFrom time.Time, dateStr string) (int64, err
 	data := response.Data
 
 	// no sale
-	if len(data) == 0 {
+	// if there are no sales response.Data is a string with "[]". Since it is a string the len of "[]" is 2
+	if len(data) == 2 {
 		return 0, nil
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -74,7 +74,7 @@ github.com/stretchr/testify/assert
 # github.com/subosito/gotenv v1.2.0
 ## explicit
 github.com/subosito/gotenv
-# github.com/vend/govend v0.0.0-20230102233450-7aa1871d7b9c
+# github.com/vend/govend v0.0.0-20230519205635-fdd70a9b4568
 ## explicit
 github.com/vend/govend/vend
 # github.com/wallclockbuilder/stringutil v0.0.0-20151229105100-650d35b119a3


### PR DESCRIPTION
Add function defer to main.go. If a panic occurs this should be the last defered function. This function catches a panic, and if there is an exit instruction in it will exit instead. Effectively this allows all deffered functions to complete before exiting, and prevents a staktrace from printing. We want to use panic instead of fatal, but for expected exits we don't need the stacktrace