### PR TITLE
Add command to fix product by converting variant into standard

### DIFF
--- a/commands/fixProductsVariantToStandard.go
+++ b/commands/fixProductsVariantToStandard.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"github.com/vend/govend/vend"
+)
+
+var fixProductsVariantToStandardCmd = &cobra.Command{
+	Use:   "fix-products-variant-to-standard",
+	Short: "Fix Products - Converting variant to standard",
+	Long: fmt.Sprintf(`
+This tool requires a CSV of Product IDs, no headers.
+
+Example:
+%s`, color.GreenString("vendcli fix-products-variant-to-standard -d DOMAINPREFIX -t TOKEN -f FILENAME.csv -r ''")),
+	Run: func(cmd *cobra.Command, args []string) {
+		fixProductsVariantToStandard()
+	},
+}
+
+var Reason string
+
+func init() {
+	// Flag
+	fixProductsVariantToStandardCmd.Flags().StringVarP(&FilePath, "Filename", "f", "", "The name of your file: filename.csv")
+	fixProductsVariantToStandardCmd.Flags().StringVarP(&Reason, "Reason", "r", "", "The reason for performing this action")
+
+	fixProductsVariantToStandardCmd.MarkFlagRequired("Filename")
+	fixProductsVariantToStandardCmd.MarkFlagRequired("Reason")
+
+	rootCmd.AddCommand(fixProductsVariantToStandardCmd)
+}
+
+type ConvertVariantToStandardRequest struct {
+	Action    string `json:"action"`
+	Reason    string `json:"reason"`
+	VariantID string `json:"variant_id"`
+}
+
+func fixProductsVariantToStandard() {
+	// Create new Vend Client.
+	vc := vend.NewClient(Token, DomainPrefix, "")
+	vendClient = &vc
+
+	if Reason == "" {
+		log.Fatalf("Please specify a reason: -r '<REASON or ticket reference FOR RUNNING THIS>'")
+	}
+
+	// Get passed entities from CSV
+	fmt.Println("\nReading CSV...")
+	ids, err := readCSV(FilePath)
+	if err != nil {
+		log.Fatalf(color.RedString("Failed to get ids from the file: %s", FilePath))
+	}
+
+	url := fmt.Sprintf("https://%s.vendhq.com/api/2.0/products/actions/bulk", DomainPrefix)
+	// Make the requests
+	maxProductsPerRequest := 10
+	reqBody := make([]ConvertVariantToStandardRequest, 0, len(ids))
+	for i, id := range ids {
+		// NOTE: This action is internal and could potentially change in a non-backward compatible manner.
+		body := ConvertVariantToStandardRequest{
+			Action:    "product.classification.convert_to_standard",
+			Reason:    Reason,
+			VariantID: id,
+		}
+		reqBody = append(reqBody, body)
+
+		if i%maxProductsPerRequest == 0 {
+			fmt.Printf("\nConverting %d variants to a standard product. \n ids: %v", len(reqBody), ids)
+			_, err = vendClient.MakeRequest(http.MethodPost, url, reqBody)
+			if err != nil {
+				fmt.Printf(color.RedString("Failed to fix product: %v", err))
+				return
+			}
+			reqBody = make([]ConvertVariantToStandardRequest, 0, maxProductsPerRequest)
+		}
+	}
+
+	if len(reqBody) > 0 {
+		_, err = vendClient.MakeRequest(http.MethodPost, url, reqBody)
+		if err != nil {
+			fmt.Printf(color.RedString("Failed to fix product: %v", err))
+		}
+	}
+
+	fmt.Println(color.GreenString("\n\nFinished! 🎉\n"))
+}

--- a/readme.md
+++ b/readme.md
@@ -28,24 +28,25 @@ Usage:
   vendcli [command]
 
 Available Commands:
-  delete-customers     Delete Customers
-  delete-products      Delete Products
-  export-auditlog      Export Audit Log
-  export-customers     Export Customers
-  export-giftcards     Export Gift Cards
-  export-images        Export Product Images
-  export-sales         Export Sales
-  export-storecredits  Export Store Credits
-  export-suppliers     Export Suppliers 
-  export-users         Export Users
-  help                 Help about any command
-  import-images        Import Product Images
-  import-product-codes Import Product Codes
-  import-storecredits  Import Store Credits
-  import-suppliers     Import Suppliers
-  loyalty-adjustment   Customer Loyalty Adjustment
-  void-giftcards       Void Gift Cards
-  void-sales           Void Sales
+  delete-customers                      Delete Customers
+  delete-products                       Delete Products
+  export-auditlog                       Export Audit Log
+  export-customers                      Export Customers
+  export-giftcards                      Export Gift Cards
+  export-images                         Export Product Images
+  export-sales                          Export Sales
+  export-storecredits                   Export Store Credits
+  export-suppliers                      Export Suppliers 
+  export-users                          Export Users
+  fix-products-variant-to-standard      Convert variant product to standard
+  help                                  Help about any command
+  import-images                         Import Product Images
+  import-product-codes                  Import Product Codes
+  import-storecredits                   Import Store Credits
+  import-suppliers                      Import Suppliers
+  loyalty-adjustment                    Customer Loyalty Adjustment
+  void-giftcards                        Void Gift Cards
+  void-sales                            Void Sales
 
 Flags:
   -d, --Domain string   The Vend store name (prefix in xxxx.vendhq.com)
@@ -68,6 +69,7 @@ Use "vendcli [command] --help" for more information about a command.
 - Export Suppliers
 - Export Audit Log
 - Export Images
+- Fix Products - Converting variant to standard
 - Import Images
 - Import Product Codes
 - Import Suppliers
@@ -119,6 +121,10 @@ When running a command you need to pass the flags that specify the parameters fo
 #### Export Images
 
 	$ vendcli export-images -d domainprefix -t token
+
+#### Fix Products - Converting variant to standard
+
+	$ vendcli fix-products-variant-to-standard -d domainprefix -t TOKEN -f FILENAME.csv -r ''
 
 #### Import Images
 


### PR DESCRIPTION
## Overview
Recently support bump into a scenario where retailer's products was wrongly a variant and needing to convert to standard product. However, there is no way to do this from the X-series app, and the only way through BE modifying the product `has_variants` is insufficient to convert the product from a variant into standard product.

To get something minimum viable that support can use , this command interfaces an existing Crayola bulk action API that can do this.

Reference [thread](https://lightspeedhq.slack.com/archives/C02JQAXD2UV/p1687123527396369)

## Running instructions

See readme changes

```
vendcli fix-products-variant-to-standard -d domainprefix -t TOKEN -f FILENAME.csv -r ''
```

__Please specify a reason in the -r option__

