### PR TITLE
govend - remove panic and print

### DIFF
--- a/commands/auditlog.go
+++ b/commands/auditlog.go
@@ -3,9 +3,10 @@ package cmd
 import (
 	"encoding/csv"
 	"fmt"
-	"log"
 	"os"
 	"time"
+
+	"github.com/vend/vend-cli/pkg/messenger"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -44,30 +45,30 @@ func getAuditLog() {
 	layout := "2006-01-02T15:04:05"
 	_, err := time.Parse(layout, dateFrom)
 	if err != nil {
-		log.Printf("incorrect date from: %v, %v", dateFrom, err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("incorrect date from: %v, %v", dateFrom, err)
+		messenger.ExitWithError(err)
 	}
 
 	_, err = time.Parse(layout, dateTo)
 	if err != nil {
-		log.Printf("incorrect date to: %v, %v", dateTo, err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("incorrect date to: %v, %v", dateTo, err)
+		messenger.ExitWithError(err)
 	}
 
 	// Get log
 	fmt.Println("\nRetrieving Audit Log from Vend...")
 	audit, err := vc.AuditLog(dateFrom, dateTo)
 	if err != nil {
-		log.Printf("failed retrieving audit log from Vend %v", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("failed retrieving audit log from Vend %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	// Write log to CSV
 	fmt.Println("Writing log to CSV file...")
 	err = aWriteFile(audit)
 	if err != nil {
-		log.Printf("failed writing audit log to CSV %v", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("failed writing audit log to CSV %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	fmt.Println(color.GreenString("\nFinished!\n"))

--- a/commands/deleteConsignments.go
+++ b/commands/deleteConsignments.go
@@ -2,7 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"log"
+
+	"github.com/vend/vend-cli/pkg/messenger"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -41,8 +42,8 @@ func deleteConsignments() {
 	fmt.Println("\nReading CSV...")
 	ids, err := readCSV(FilePath)
 	if err != nil {
-		log.Printf(color.RedString("Failed to get IDs from the file: %s", FilePath))
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed to get IDs from the file: %s", FilePath)
+		messenger.ExitWithError(err)
 	}
 
 	// Make the requests

--- a/commands/deleteCustomers.go
+++ b/commands/deleteCustomers.go
@@ -3,9 +3,10 @@ package cmd
 import (
 	"encoding/csv"
 	"fmt"
-	"log"
 	"os"
 	"time"
+
+	"github.com/vend/vend-cli/pkg/messenger"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -49,8 +50,8 @@ func deleteCustomers() {
 	fmt.Println("\nReading CSV...")
 	ids, err := readCSV(FilePath)
 	if err != nil {
-		log.Printf(color.RedString("Failed to get IDs from the file: %s", FilePath))
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed to get IDs from the file: %s", FilePath)
+		messenger.ExitWithError(err)
 	}
 
 	failedRequests := []FailedCustomerDeleteRequest{}
@@ -80,8 +81,8 @@ func saveFailedCustomerDeleteRequestsToCSV(failedRequests []FailedCustomerDelete
 	// Create a new CSV file
 	file, err := os.Create(fileName)
 	if err != nil {
-		log.Printf(color.RedString("Failed to create file: %s", "failed-requests.csv"))
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed to create file: %s", fileName)
+		messenger.ExitWithError(err)
 	}
 	defer file.Close()
 

--- a/commands/deleteImages.go
+++ b/commands/deleteImages.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/vend/vend-cli/pkg/messenger"
+
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/vend/govend/vend"
@@ -42,7 +44,7 @@ func deleteImages() {
 	ids, err := readCSV(FilePath)
 	if err != nil {
 		log.Printf(color.RedString("Failed to get IDs from the file: %s", FilePath))
-		panic(vend.Exit{1})
+		messenger.ExitWithError(err)
 	}
 
 	// Make the requests

--- a/commands/deleteProducts.go
+++ b/commands/deleteProducts.go
@@ -2,7 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"log"
+
+	"github.com/vend/vend-cli/pkg/messenger"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -41,8 +42,8 @@ func deleteProducts() {
 	fmt.Println("\nReading CSV...")
 	ids, err := readCSV(FilePath)
 	if err != nil {
-		log.Printf(color.RedString("Failed to get ids from the file: %s", FilePath))
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed to get ids from the file: %s", FilePath)
+		messenger.ExitWithError(err)
 	}
 
 	// Make the requests

--- a/commands/exportCustomers.go
+++ b/commands/exportCustomers.go
@@ -3,9 +3,10 @@ package cmd
 import (
 	"encoding/csv"
 	"fmt"
-	"log"
 	"os"
 	"time"
+
+	"github.com/vend/vend-cli/pkg/messenger"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -39,22 +40,22 @@ func getAllCustomers() {
 	fmt.Println("\nRetrieving Customers from Vend...")
 	customers, err := vc.Customers()
 	if err != nil {
-		log.Printf("Failed retrieving customers from Vend %v", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed retrieving customers from Vend %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	customerGroupMap, err := vc.CustomerGroups()
 	if err != nil {
-		log.Printf("Failed retrieving customer groups from Vend %v", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed retrieving customer groups from Vend %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	// Write Customers to CSV
 	fmt.Println("Writing customers to CSV file...")
 	err = cWriteFile(customers, customerGroupMap)
 	if err != nil {
-		log.Printf(color.RedString("Failed writing customers to CSV: %v", err))
-		panic(vend.Exit{1})
+		err = fmt.Errorf(color.RedString("Failed writing customers to CSV: %v", err))
+		messenger.ExitWithError(err)
 	}
 
 	fmt.Println(color.GreenString("\nExported %v customers  🎉\n", len(customers)))

--- a/commands/exportGiftcards.go
+++ b/commands/exportGiftcards.go
@@ -3,9 +3,10 @@ package cmd
 import (
 	"encoding/csv"
 	"fmt"
-	"log"
 	"os"
 	"time"
+
+	"github.com/vend/vend-cli/pkg/messenger"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -39,16 +40,16 @@ func getGiftCards() {
 	fmt.Println("\nRetrieving Gift Cards from Vend...")
 	giftCards, err := vc.GiftCards()
 	if err != nil {
-		log.Printf(color.RedString("Failed while retrieving Gift Cards: %v", err))
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed while retrieving Gift Cards: %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	// Write Gift Cards to CSV
 	fmt.Println("Writing Gift Cards to CSV file...")
 	err = gcWriterFile(giftCards)
 	if err != nil {
-		log.Printf(color.RedString("Failed while writing Gift Cards to CSV: %v", err))
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed while writing Gift Cards to CSV: %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	fmt.Println(color.GreenString("\nExported %v Gift Cards 🎉\n", len(giftCards)))
@@ -61,8 +62,8 @@ func gcWriterFile(giftCards []vend.GiftCard) error {
 	fileName := fmt.Sprintf("%s_giftcard_export_%v.csv", DomainPrefix, time.Now().Unix())
 	file, err := os.Create(fmt.Sprintf("./%s", fileName))
 	if err != nil {
-		log.Printf(color.RedString("Failed to create CSV: %v", err))
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed to create CSV: %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	// Ensure the file is closed at the end.

--- a/commands/exportImages.go
+++ b/commands/exportImages.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/vend/vend-cli/pkg/messenger"
+
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/vend/govend/vend"
@@ -58,16 +60,16 @@ func getAllImages() {
 	fmt.Println("\nRetrieving Images from Vend...")
 	images, _, err := vc.Products()
 	if err != nil {
-		log.Printf(color.RedString("Failed while retrieving images: %v", err))
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed while retrieving images: %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	// Write to CSV
 	fmt.Println("Writing images to CSV file...")
 	err = iWriteFile(images, detailsBool)
 	if err != nil {
-		log.Printf(color.RedString("Failed while writing images to CSV: %v", err))
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed while writing images to CSV: %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	fmt.Println(color.GreenString("\nFinished!\n"))
@@ -82,8 +84,8 @@ func iWriteFile(products []vend.Product, details bool) error {
 	fileName := fmt.Sprintf("%s_image_export_%v.csv", DomainPrefix, time.Now().Unix())
 	file, err := os.Create(fmt.Sprintf("./%s", fileName))
 	if err != nil {
-		log.Printf("Failed to create CSV: %v", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed to create CSV: %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	// Ensure the file is closed at the end.

--- a/commands/exportOutlets.go
+++ b/commands/exportOutlets.go
@@ -3,9 +3,10 @@ package cmd
 import (
 	"encoding/csv"
 	"fmt"
-	"log"
 	"os"
 	"time"
+
+	"github.com/vend/vend-cli/pkg/messenger"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -38,14 +39,14 @@ func exportOutlets() {
 	// Get Outlets
 	outlets, _, err := vc.Outlets()
 	if err != nil {
-		log.Printf("Failed retrieving outlets from Vend %v", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed retrieving outlets from Vend %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	file, err := createOutletReport(DomainPrefix)
 	if err != nil {
-		log.Printf("Failed creating CSV file %v", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed creating CSV file %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	file = addHeaderOutletReport(file)

--- a/commands/exportProducts.go
+++ b/commands/exportProducts.go
@@ -3,12 +3,13 @@ package cmd
 import (
 	"encoding/csv"
 	"fmt"
-	"log"
 	"os"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/vend/vend-cli/pkg/messenger"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -44,8 +45,8 @@ func getAllProducts() {
 	fmt.Println("\nRetrieving Products...")
 	products, _, err := vc.Products()
 	if err != nil {
-		log.Printf("Failed retrieving products from Vend %v", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed retrieving products from Vend %v", err)
+		messenger.ExitWithError(err)
 	}
 	catalogStats.TotalInventory = int64(len(products))
 	// Get Max Supplier
@@ -58,22 +59,22 @@ func getAllProducts() {
 	// Get Outlets
 	outlets, outletsMap, err := vc.Outlets()
 	if err != nil {
-		log.Printf("Failed retrieving outlets from Vend %v", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed retrieving outlets from Vend %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	// Get Outlet Taxes
 	outletTaxes, err := vc.OutletTaxes()
 	if err != nil {
-		log.Printf("Failed retrieving outlet taxes from Vend %v", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed retrieving outlet taxes from Vend %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	// Get Taxes
 	_, taxMaps, err := vc.Taxes()
 	if err != nil {
-		log.Printf("Failed retrieving taxes from Vend %v", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed retrieving taxes from Vend %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	// Get Inventory
@@ -96,8 +97,8 @@ func getAllProducts() {
 	fmt.Printf("Writing products to CSV file...\n")
 	err = productsWriteFile(products, outlets, outletsMap, recordsMap, outletTaxesMap, tagsMap, maxSupplier, SKUCodesMap, maxSkuType)
 	if err != nil {
-		log.Printf(color.RedString("Failed writing products to CSV: %v", err))
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed writing products to CSV: %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	// Print happy message, and then display catalog stats

--- a/commands/exportStorecredits.go
+++ b/commands/exportStorecredits.go
@@ -3,9 +3,10 @@ package cmd
 import (
 	"encoding/csv"
 	"fmt"
-	"log"
 	"os"
 	"time"
+
+	"github.com/vend/vend-cli/pkg/messenger"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -39,8 +40,8 @@ func getStoreCredits() {
 	fmt.Println("\nRetrieving Store Credits from Vend...")
 	storeCredits, err := vc.StoreCredits()
 	if err != nil {
-		log.Printf("Failed while retrieving store credits: %v", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed while retrieving store credits: %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	// // Find Customer ID from Customer Code
@@ -55,8 +56,8 @@ func getStoreCredits() {
 	fmt.Println("Writing Store Credits to CSV file...")
 	err = scWriterFile(storeCredits)
 	if err != nil {
-		log.Printf("Failed while writing Store Credits to CSV: %v", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed while writing Store Credits to CSV: %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	fmt.Println(color.GreenString("\nExported %v Store Credits\n", len(storeCredits)))
@@ -69,8 +70,8 @@ func scWriterFile(sc []vend.StoreCredit) error {
 	fileName := fmt.Sprintf("%s_storecredit_export_%v.csv", DomainPrefix, time.Now().Unix())
 	file, err := os.Create(fmt.Sprintf("./%s", fileName))
 	if err != nil {
-		log.Printf("Failed to create CSV: %v", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed to create CSV: %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	// Ensure the file is closed at the end.

--- a/commands/exportSuppliers.go
+++ b/commands/exportSuppliers.go
@@ -3,9 +3,10 @@ package cmd
 import (
 	"encoding/csv"
 	"fmt"
-	"log"
 	"os"
 	"time"
+
+	"github.com/vend/vend-cli/pkg/messenger"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -38,16 +39,16 @@ func getAllSuppliers() {
 	fmt.Println("\nRetrieving Suppliers from Vend...")
 	suppliers, err := vc.Suppliers()
 	if err != nil {
-		log.Printf("Failed while retrieving Suppliers: %v", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed while retrieving Suppliers: %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	// Write Suppliers to CSV
 	fmt.Println("Writing Suppliers to CSV file...")
 	err = sWriteFile(suppliers)
 	if err != nil {
-		log.Printf("Failed while writing Suppliers to CSV: %v", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed while writing Suppliers to CSV: %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	fmt.Println(color.GreenString("\nFinished!\n"))
@@ -60,8 +61,8 @@ func sWriteFile(suppliers []vend.SupplierBase) error {
 	fileName := fmt.Sprintf("%s_supplier_export_%v.csv", DomainPrefix, time.Now().Unix())
 	file, err := os.Create(fmt.Sprintf("./%s", fileName))
 	if err != nil {
-		log.Printf("Failed while creating CSV %v", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed while creating CSV %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	// Ensure the file is closed at the end.

--- a/commands/exportusers.go
+++ b/commands/exportusers.go
@@ -3,9 +3,10 @@ package cmd
 import (
 	"encoding/csv"
 	"fmt"
-	"log"
 	"os"
 	"time"
+
+	"github.com/vend/vend-cli/pkg/messenger"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -39,16 +40,16 @@ func getAllUsers() {
 	fmt.Println("\nRetrieving Users from Vend...")
 	users, err := vc.Users()
 	if err != nil {
-		log.Printf("Failed retrieving Users from Vend %v", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed retrieving Users from Vend %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	// Write Users to CSV
 	fmt.Println("Writing Users to CSV file...")
 	err = uWriteFile(users)
 	if err != nil {
-		log.Printf("Failed writing Users to CSV: %v", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed writing Users to CSV: %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	fmt.Println(color.GreenString("\nExported %v Users\n", len(users)))

--- a/commands/importImages.go
+++ b/commands/importImages.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vend/vend-cli/pkg/messenger"
+
 	"github.com/fatih/color"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -55,8 +57,8 @@ func importImages(FilePath string) {
 	fmt.Println("\nReading products from CSV file...")
 	productsFromCSV, err := ReadImageCSV(FilePath)
 	if err != nil {
-		log.Printf("Error reading CSV file")
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Error reading CSV file")
+		messenger.ExitWithError(err)
 	}
 
 	// Get all products from Vend.
@@ -292,7 +294,8 @@ func urlGet(url string) ([]byte, error) {
 	defer res.Body.Close()
 
 	// Check HTTP response.
-	if !vend.ResponseCheck(res.StatusCode) {
+	err = vend.ResponseCheck(res.StatusCode)
+	if err != nil {
 		fmt.Printf("Status Code: %v", res.StatusCode)
 		return nil, err
 	}
@@ -344,8 +347,8 @@ func UploadImage(imagePath string, product vend.ProductUpload) error {
 		// Copying image binary to form file.
 		_, err = io.Copy(part, file)
 		if err != nil {
-			log.Printf("Error copying file for requst body: %s", err)
-			panic(vend.Exit{1})
+			err = fmt.Errorf("Error copying file for requst body: %s", err)
+			messenger.ExitWithError(err)
 		}
 
 		err = writer.Close()
@@ -387,7 +390,8 @@ func UploadImage(imagePath string, product vend.ProductUpload) error {
 			}
 		}
 		// Add status code check
-		if !vend.ResponseCheck(res.StatusCode) {
+		err = vend.ResponseCheck(res.StatusCode)
+		if err != nil {
 			response := vend.Errors{}
 			resBody, _ := ioutil.ReadAll(res.Body)
 			json.Unmarshal(resBody, &response)
@@ -409,8 +413,8 @@ func UploadImage(imagePath string, product vend.ProductUpload) error {
 		response := vend.ImageUpload{}
 		err = json.Unmarshal(resBody, &response)
 		if err != nil {
-			fmt.Println("error sourcing image - please check the image URL. Image links must be a direct link to the image.")
-			panic(vend.Exit{1})
+			err = fmt.Errorf("error sourcing image - please check the image URL. Image links must be a direct link to the image.")
+			messenger.ExitWithError(err)
 			return err
 		}
 

--- a/commands/importProductCodes.go
+++ b/commands/importProductCodes.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/vend/vend-cli/pkg/messenger"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -67,15 +68,15 @@ func importProductCodes() {
 	fmt.Println("Reading product codes CSV...")
 	productCodes, err := readProductCodesCSV(FilePath)
 	if err != nil {
-		log.Printf("Couldnt read Product Code CSV file, %s", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Couldnt read Product Code CSV file, %s", err)
+		messenger.ExitWithError(err)
 	}
 
 	// Post Product Codes to Vend
 	err = postProductCodes(productCodes)
 	if err != nil {
-		log.Printf("Failed to post product codes, %s", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed to post product codes, %s", err)
+		messenger.ExitWithError(err)
 	}
 
 	fmt.Println(color.GreenString("\nFinished!\n"))

--- a/commands/importSuppliers.go
+++ b/commands/importSuppliers.go
@@ -3,8 +3,9 @@ package cmd
 import (
 	"encoding/csv"
 	"fmt"
-	"log"
 	"os"
+
+	"github.com/vend/vend-cli/pkg/messenger"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -44,15 +45,15 @@ func importSuppliers() {
 	fmt.Println("\nReading Supplier CSV...")
 	suppliers, err := readSupplierCSV(FilePath)
 	if err != nil {
-		log.Printf("Couldnt read Supplier CSV file, %s", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Couldnt read Supplier CSV file, %s", err)
+		messenger.ExitWithError(err)
 	}
 
 	// Post Suppliers to Vend
 	err = postSuppliers(suppliers)
 	if err != nil {
-		log.Printf("Failed to post Suppliers, %s", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed to post Suppliers, %s", err)
+		messenger.ExitWithError(err)
 	}
 
 	fmt.Println(color.GreenString("\nFinished!\n"))
@@ -89,10 +90,9 @@ Tip: make sure you're in the same folder as your file. Use "cd ~/Downloads" to n
 	// Check each header in the row is same as our template.
 	for i := range headerRow {
 		if headerRow[i] != headers[i] {
-			fmt.Println("Found error in header rows.")
-			log.Printf("No header match for: %s Instead got: %s.",
+			err = fmt.Errorf("Found error in header rows.\nNo header match for: %s Instead got: %s.",
 				string(headers[i]), string(headerRow[i]))
-			panic(vend.Exit{1})
+			messenger.ExitWithError(err)
 
 		}
 	}

--- a/commands/loyaltyAdjustment.go
+++ b/commands/loyaltyAdjustment.go
@@ -3,8 +3,9 @@ package cmd
 import (
 	"encoding/csv"
 	"fmt"
-	"log"
 	"os"
+
+	"github.com/vend/vend-cli/pkg/messenger"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -44,8 +45,8 @@ func loyaltyAdjustment() {
 	fmt.Println("\nReading Loyalty Adjustment CSV...")
 	loyaltyAdjustments, err := readLoyaltyAdjustmentCSV(FilePath)
 	if err != nil {
-		log.Printf("Couldnt read Loyalty Adjustment CSV file,  %s", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Couldnt read Loyalty Adjustment CSV file,  %s", err)
+		messenger.ExitWithError(err)
 	}
 
 	// Posting Adjustments to Vend
@@ -93,10 +94,9 @@ Tip: make sure you're in the same folder as your file. Use "cd ~/Downloads" to n
 	// Check each header in the row is same as our template.
 	for i := range headerRow {
 		if headerRow[i] != headers[i] {
-			fmt.Println("Found error in header rows.")
-			log.Printf("No header match for: %s Instead got: %s.",
+			err = fmt.Errorf("Found error in hearder rows.\nNo header match for: %s Instead got: %s.",
 				string(headers[i]), string(headerRow[i]))
-			panic(vend.Exit{1})
+			messenger.ExitWithError(err)
 
 		}
 	}

--- a/commands/root.go
+++ b/commands/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/vend/govend/vend"
+	"github.com/vend/vend-cli/pkg/messenger"
 )
 
 const version = "1.8"
@@ -47,8 +48,7 @@ func init() {
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		panic(vend.Exit{1})
+		messenger.ExitWithError(err)
 	}
 }
 
@@ -61,8 +61,7 @@ func initConfig() {
 		// Find home directory.
 		home, err := homedir.Dir()
 		if err != nil {
-			fmt.Println(err)
-			panic(vend.Exit{1})
+			messenger.ExitWithError(err)
 		}
 
 		// Search config in home directory with name ".vend" (without extension).

--- a/commands/updateSaleID.go
+++ b/commands/updateSaleID.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vend/vend-cli/pkg/messenger"
+
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/vend/govend/vend"
@@ -64,8 +66,8 @@ func updateSaleID() {
 	logFileName := fmt.Sprintf("%s_post_in_case_of_emergency_%v.txt", DomainPrefix, time.Now().Unix())
 	logFile, err := os.OpenFile(fmt.Sprintf("./%s", logFileName), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
-		log.Printf("error:%s", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("error:%s", err)
+		messenger.ExitWithError(err)
 	}
 	log.SetOutput(logFile)
 

--- a/commands/updateSaleInvoiceNumber.go
+++ b/commands/updateSaleInvoiceNumber.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vend/vend-cli/pkg/messenger"
+
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/vend/govend/vend"
@@ -69,8 +71,7 @@ func updateSaleInvoice() {
 	logFileName := fmt.Sprintf("%s_post_in_case_of_emergency_%v.txt", DomainPrefix, time.Now().Unix())
 	logFile, err := os.OpenFile(fmt.Sprintf("./%s", logFileName), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
-		log.Printf("error:%s", err)
-		panic(vend.Exit{1})
+		messenger.ExitWithError(err)
 	}
 	log.SetOutput(logFile)
 

--- a/commands/voidGiftcards.go
+++ b/commands/voidGiftcards.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/vend/vend-cli/pkg/messenger"
+
 	"github.com/fatih/color"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
@@ -65,23 +67,23 @@ func voidGiftCards() {
 	// Get user ID from token. This also checks if the token is valid.
 	user, err := vc.User()
 	if err != nil {
-		fmt.Printf("Failed to get user ID from token - check your token")
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed to get user ID from token - check your token")
+		messenger.ExitWithError(err)
 	}
 
 	// Fetch gift card data
 	giftCards, err := vc.GiftCards()
 	if err != nil {
-		fmt.Printf("Failed to fetch gift card data: %v", err)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed to fetch gift card data: %v", err)
+		messenger.ExitWithError(err)
 	}
 
 	// Get Gift Card Numbers from CSV
 	fmt.Printf("\nReading Gift Card CSV\n")
 	ids, err := readGiftCardCSV(FilePath)
 	if err != nil {
-		fmt.Printf("Failed to get gift card numbers from the file: %s", FilePath)
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed to get gift card numbers from the file: %s", FilePath)
+		messenger.ExitWithError(err)
 	}
 
 	giftCardBalances := makeGCHash(giftCards)
@@ -90,8 +92,8 @@ func voidGiftCards() {
 	if user.ID != nil {
 		userID = *user.ID
 	} else {
-		fmt.Printf("Failed to get user ID from token - check your token")
-		panic(vend.Exit{1})
+		err = fmt.Errorf("Failed to get user ID from token - check your token")
+		messenger.ExitWithError(err)
 	}
 
 	// Voiding Gift Cards
@@ -204,9 +206,9 @@ Tip: make sure you're in the same folder as your file. Use "cd ~/Downloads" to n
 	for i := range headerRow {
 		if headerRow[i] != headers[i] {
 			fmt.Println("Found error in header rows.")
-			fmt.Printf("No header match for: %s Instead got: %s.\n",
+			err = fmt.Errorf("Found error in header rows.\nNo header match for: %s Instead got: %s.\n",
 				string(headers[i]), string(headerRow[i]))
-			panic(vend.Exit{1})
+			messenger.ExitWithError(err)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.3.0
-	github.com/vend/govend v0.4.1
+	github.com/vend/govend v0.5.0
 	github.com/wallclockbuilder/stringutil v0.0.0-20151229105100-650d35b119a3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/vend/govend v0.4.1 h1:ZAbKETReHPrmJruJL9/3GPpRzFlALJsFVMTG7pjuZEE=
-github.com/vend/govend v0.4.1/go.mod h1:aQ2GJpu83dBAhnWesMXy9cxW7TOWcHgMAu/PQ33CPv4=
+github.com/vend/govend v0.5.0 h1:KsvKs9wru3RW9/5etafQZsp06P4OGjsdBXY/jK8tJ2U=
+github.com/vend/govend v0.5.0/go.mod h1:aQ2GJpu83dBAhnWesMXy9cxW7TOWcHgMAu/PQ33CPv4=
 github.com/wallclockbuilder/stringutil v0.0.0-20151229105100-650d35b119a3 h1:nxWV9UNdGHW3OezVTq99ak99RvqMM+H+oG+aKNraxT4=
 github.com/wallclockbuilder/stringutil v0.0.0-20151229105100-650d35b119a3/go.mod h1:P0XJ0/hGOuePFbpFCHyzHMls2afcv32GHlmL/VuIpHg=
 github.com/wallclockbuilder/testify v0.0.0-20150512124233-dab07ac62d49 h1:2q+dCr8jqV705ORsqrqTATbsXAUQbYr6iSnPY7EVzWY=

--- a/main.go
+++ b/main.go
@@ -1,11 +1,26 @@
 package main
 
 import (
-	"github.com/vend/govend/vend"
+	"fmt"
+	"os"
+
+	"github.com/fatih/color"
 	cmd "github.com/vend/vend-cli/commands"
+	"github.com/vend/vend-cli/pkg/messenger"
 )
 
+func SupressStackTrace() {
+	if r := recover(); r != nil {
+		if exit, ok := r.(messenger.Exit); ok {
+			fmt.Println(color.RedString("\n\nvendcli exited because an error occured:"))
+			fmt.Println(color.YellowString(fmt.Sprintf("%s", exit.Message)))
+			os.Exit(exit.Code)
+		}
+		panic(r) // not an Exit, bubble up
+	}
+}
+
 func main() {
-	defer vend.SupressStackTrace()
+	defer SupressStackTrace()
 	cmd.Execute()
 }

--- a/pkg/messenger/messenger.go
+++ b/pkg/messenger/messenger.go
@@ -1,0 +1,11 @@
+package messenger
+
+// Exit is for exiting gracefully when using panic
+type Exit struct {
+	Code    int
+	Message error
+}
+
+func ExitWithError(err error) {
+	panic(Exit{1, err})
+}

--- a/vendor/github.com/vend/govend/vend/auditlog.go
+++ b/vendor/github.com/vend/govend/vend/auditlog.go
@@ -31,10 +31,13 @@ func (c *Client) AuditLog(dateFrom, dateTo string) ([]AuditLog, error) {
 	// Build the URL for the endpoint.
 	url := fmt.Sprintf("https://%s.vendhq.com/api/2.0/auditlog_events?from=%s&to=%s&offset=%v", c.DomainPrefix, dateFrom, dateTo, currentOffset)
 	data, err := c.MakeRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
 	response := &AuditResponse{}
 	err = json.Unmarshal(data, response)
 	if err != nil {
-		fmt.Printf("\nError unmarshalling Vend register payload: %s", err)
+		err = fmt.Errorf("\nError unmarshalling Vend register payload: %s", err)
 		return nil, err
 	}
 
@@ -50,10 +53,13 @@ func (c *Client) AuditLog(dateFrom, dateTo string) ([]AuditLog, error) {
 		// Build the URL for the endpoint including the offset
 		url := fmt.Sprintf("https://%s.vendhq.com/api/2.0/auditlog_events?from=%s&to=%s&offset=%v", c.DomainPrefix, dateFrom, dateTo, currentOffset)
 		data, err := c.MakeRequest("GET", url, nil)
+		if err != nil {
+			return audit, err
+		}
 		response := &AuditResponse{}
 		err = json.Unmarshal(data, response)
 		if err != nil {
-			fmt.Printf("\nError unmarshalling Vend register payload: %s", err)
+			err = fmt.Errorf("\nError unmarshalling Vend register payload: %s", err)
 			return audit, err
 		}
 

--- a/vendor/github.com/vend/govend/vend/consignment.go
+++ b/vendor/github.com/vend/govend/vend/consignment.go
@@ -3,7 +3,7 @@ package vend
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 	"time"
 )
 
@@ -34,9 +34,13 @@ func (c *Client) Consignments() ([]Consignment, error) {
 
 	// v is a version that is used to objects by page.
 	data, v, err := c.ResourcePage(0, "GET", "consignments")
+	if err != nil {
+		return consignments, err
+	}
 	err = json.Unmarshal(data, &page)
 	if err != nil {
-		log.Printf("error while unmarshalling: %s", err)
+		err = fmt.Errorf("error while unmarshalling: %s", err)
+		return consignments, err
 	}
 
 	consignments = append(consignments, page...)
@@ -45,7 +49,14 @@ func (c *Client) Consignments() ([]Consignment, error) {
 	for len(data) > 2 {
 		page = []Consignment{}
 		data, v, err = c.ResourcePage(v, "GET", "consignments")
+		if err != nil {
+			return consignments, err
+		}
 		err = json.Unmarshal(data, &page)
+		if err != nil {
+			err = fmt.Errorf("error while unmarshalling: %s", err)
+			return consignments, err
+		}
 		consignments = append(consignments, page...)
 	}
 

--- a/vendor/github.com/vend/govend/vend/consignmentproduct.go
+++ b/vendor/github.com/vend/govend/vend/consignmentproduct.go
@@ -51,13 +51,14 @@ func (c *Client) ConsignmentProducts(consignments *[]Consignment) ([]Consignment
 
 		body, err := c.MakeRequest("GET", URL, nil)
 		if err != nil {
-			fmt.Printf("Error getting resource: %s", err)
+			err = fmt.Errorf("Error getting resource: %s", err)
+			return []ConsignmentProduct{}, nil, err
 		}
 
 		// Decode the JSON into our defined consignment object.
 		err = json.Unmarshal(body, &response)
 		if err != nil {
-			fmt.Printf("\nError unmarshalling Vend consignment payload: %s", err)
+			err = fmt.Errorf("\nError unmarshalling Vend consignment payload: %s", err)
 			return []ConsignmentProduct{}, nil, err
 		}
 

--- a/vendor/github.com/vend/govend/vend/customer.go
+++ b/vendor/github.com/vend/govend/vend/customer.go
@@ -3,7 +3,7 @@ package vend
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 )
 
 // Vend API Docs: https://docs.vendhq.com/v0.9/reference#customers-2
@@ -69,9 +69,13 @@ func (c *Client) Customers() ([]Customer, error) {
 
 	// v is a version that is used to get customers by page.
 	data, v, err := c.ResourcePage(0, "GET", "customers")
+	if err != nil {
+		return customers, err
+	}
 	err = json.Unmarshal(data, &page)
 	if err != nil {
-		log.Printf("error while unmarshalling: %s", err)
+		err = fmt.Errorf("error while unmarshalling: %s", err)
+		return customers, err
 	}
 
 	customers = append(customers, page...)
@@ -80,7 +84,14 @@ func (c *Client) Customers() ([]Customer, error) {
 	for len(page) > 0 {
 		page = []Customer{}
 		data, v, err = c.ResourcePage(v, "GET", "customers")
+		if err != nil {
+			return customers, err
+		}
 		err = json.Unmarshal(data, &page)
+		if err != nil {
+			err = fmt.Errorf("error while unmarshalling: %s", err)
+			return customers, err
+		}
 		customers = append(customers, page...)
 	}
 
@@ -92,9 +103,13 @@ func (c *Client) CustomerGroups() (map[string]string, error) {
 	page := []CustomerGroups{}
 
 	data, v, err := c.ResourcePage(0, "GET", "customer_groups")
+	if err != nil {
+		return nil, err
+	}
 	err = json.Unmarshal(data, &page)
 	if err != nil {
-		log.Printf("error while unmarshalling: %s", err)
+		err = fmt.Errorf("error while unmarshalling: %s", err)
+		return nil, err
 	}
 
 	groups = append(groups, page...)
@@ -102,7 +117,14 @@ func (c *Client) CustomerGroups() (map[string]string, error) {
 	for len(page) > 0 {
 		page = []CustomerGroups{}
 		data, v, err = c.ResourcePage(v, "GET", "customer_groups")
+		if err != nil {
+			return nil, err
+		}
 		err = json.Unmarshal(data, &page)
+		if err != nil {
+			err = fmt.Errorf("error while unmarshalling: %s", err)
+			return nil, err
+		}
 		groups = append(groups, page...)
 
 	}

--- a/vendor/github.com/vend/govend/vend/inventory.go
+++ b/vendor/github.com/vend/govend/vend/inventory.go
@@ -2,7 +2,7 @@ package vend
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 )
 
 // Inventory struct houses Inventory data
@@ -26,9 +26,13 @@ func (c *Client) Inventory() ([]InventoryRecord, error) {
 
 	// v is a version that is used to get registers by page.
 	data, v, err := c.ResourcePage(0, "GET", "inventory")
+	if err != nil {
+		return inventoryRecords, err
+	}
 	err = json.Unmarshal(data, &page)
 	if err != nil {
-		log.Printf("error while unmarshalling: %s", err)
+		err = fmt.Errorf("error while unmarshalling: %s", err)
+		return inventoryRecords, err
 	}
 
 	inventoryRecords = append(inventoryRecords, page...)
@@ -37,9 +41,13 @@ func (c *Client) Inventory() ([]InventoryRecord, error) {
 	for len(page) > 0 {
 		page = []InventoryRecord{}
 		data, v, err = c.ResourcePage(v, "GET", "inventory")
+		if err != nil {
+			return inventoryRecords, err
+		}
 		err = json.Unmarshal(data, &page)
 		if err != nil {
-			log.Printf("error while unmarshalling: %s", err)
+			err = fmt.Errorf("error while unmarshalling: %s", err)
+			return inventoryRecords, err
 		}
 		inventoryRecords = append(inventoryRecords, page...)
 	}

--- a/vendor/github.com/vend/govend/vend/outlet.go
+++ b/vendor/github.com/vend/govend/vend/outlet.go
@@ -3,7 +3,7 @@ package vend
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 	"time"
 )
 
@@ -30,9 +30,13 @@ func (c *Client) Outlets() ([]Outlet, map[string][]Outlet, error) {
 
 	// v is a version that is used to get outlets by page.
 	data, v, err := c.ResourcePage(0, "GET", "outlets")
+	if err != nil {
+		return outlets, nil, err
+	}
 	err = json.Unmarshal(data, &page)
 	if err != nil {
-		log.Printf("error while unmarshalling: %s", err)
+		err = fmt.Errorf("error while unmarshalling: %s", err)
+		return outlets, nil, err
 	}
 
 	outlets = append(outlets, page...)
@@ -41,7 +45,14 @@ func (c *Client) Outlets() ([]Outlet, map[string][]Outlet, error) {
 	for len(page) > 0 {
 		page = []Outlet{}
 		data, v, err = c.ResourcePage(v, "GET", "outlets")
+		if err != nil {
+			return outlets, nil, err
+		}
 		err = json.Unmarshal(data, &page)
+		if err != nil {
+			err = fmt.Errorf("error while unmarshalling: %s", err)
+			return outlets, nil, err
+		}
 		outlets = append(outlets, page...)
 	}
 

--- a/vendor/github.com/vend/govend/vend/products.go
+++ b/vendor/github.com/vend/govend/vend/products.go
@@ -4,7 +4,6 @@ package vend
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 )
 
 // Product is a basic product object based on /2.0/products endpoint
@@ -201,9 +200,12 @@ func (c *Client) Products() ([]Product, map[string]Product, error) {
 
 	// v is a version that is used to get products by page.
 	data, v, err := c.ResourcePage(0, "GET", "products")
+	if err != nil {
+		return products, productMap, err
+	}
 	err = json.Unmarshal(data, &page)
 	if err != nil {
-		log.Printf("error while unmarshalling: %s", err)
+		return products, productMap, err
 	}
 
 	products = append(products, page...)
@@ -212,7 +214,13 @@ func (c *Client) Products() ([]Product, map[string]Product, error) {
 	for len(page) > 0 {
 		page = []Product{}
 		data, v, err = c.ResourcePage(v, "GET", "products")
+		if err != nil {
+			return products, productMap, err
+		}
 		err = json.Unmarshal(data, &page)
+		if err != nil {
+			return products, productMap, err
+		}
 		products = append(products, page...)
 	}
 
@@ -237,9 +245,13 @@ func (c *Client) Tags() (map[string]string, error) {
 	page := []Tags{}
 
 	data, v, err := c.ResourcePage(0, "GET", "tags")
+	if err != nil {
+		return nil, err
+	}
 	err = json.Unmarshal(data, &page)
 	if err != nil {
-		log.Printf("error while unmarshalling: %s", err)
+		err = fmt.Errorf("error while unmarshalling: %s", err)
+		return nil, err
 	}
 
 	tags = append(tags, page...)

--- a/vendor/github.com/vend/govend/vend/register.go
+++ b/vendor/github.com/vend/govend/vend/register.go
@@ -3,7 +3,7 @@ package vend
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 	"time"
 )
 
@@ -30,9 +30,13 @@ func (c *Client) Registers() ([]Register, error) {
 
 	// v is a version that is used to get registers by page.
 	data, v, err := c.ResourcePage(0, "GET", "registers")
+	if err != nil {
+		return registers, err
+	}
 	err = json.Unmarshal(data, &page)
 	if err != nil {
-		log.Printf("error while unmarshalling: %s", err)
+		err = fmt.Errorf("error while unmarshalling: %s", err)
+		return registers, err
 	}
 
 	registers = append(registers, page...)

--- a/vendor/github.com/vend/govend/vend/sale.go
+++ b/vendor/github.com/vend/govend/vend/sale.go
@@ -3,7 +3,6 @@ package vend
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"time"
 )
 
@@ -130,9 +129,12 @@ func salesAfterVersion(version int64, c *Client) ([]Sale, error) {
 
 	// v is a version that is used to get customers by page.
 	data, v, err := c.ResourcePage(version, "GET", "sales")
+	if err != nil {
+		return sales, err
+	}
 	err = json.Unmarshal(data, &page)
 	if err != nil {
-		log.Printf("error while unmarshalling: %s", err)
+		fmt.Errorf("error while unmarshalling: %s", err)
 	}
 
 	sales = append(sales, page...)
@@ -141,7 +143,14 @@ func salesAfterVersion(version int64, c *Client) ([]Sale, error) {
 	for len(page) > 0 {
 		page = []Sale{}
 		data, v, err = c.ResourcePage(v, "GET", "sales")
+		if err != nil {
+			return sales, err
+		}
 		err = json.Unmarshal(data, &page)
+		if err != nil {
+			err = fmt.Errorf("error while unmarshalling: %s", err)
+			return sales, err
+		}
 		sales = append(sales, page...)
 	}
 
@@ -170,7 +179,7 @@ func (c *Client) GetStartVersion(dateFrom time.Time, dateStr string) (int64, err
 
 	err = json.Unmarshal(body, &response)
 	if err != nil {
-		fmt.Printf("Error unmarshalling payload: %s", err)
+		err = fmt.Errorf("Error unmarshalling payload: %s", err)
 		return 0, err
 	}
 

--- a/vendor/github.com/vend/govend/vend/storecredits.go
+++ b/vendor/github.com/vend/govend/vend/storecredits.go
@@ -54,7 +54,7 @@ func (c *Client) StoreCredits() ([]StoreCredit, error) {
 	url := fmt.Sprintf("https://%v.vendhq.com/api/2.0/store_credits?page_size=%d", c.DomainPrefix, storeCreditLimit)
 	data, err := c.MakeRequest("GET", url, nil)
 	if err != nil {
-		return []StoreCredit{}, fmt.Errorf("failed to retrieve a page of data %v", err)
+		return []StoreCredit{}, fmt.Errorf("failed to retrieve a page of data: %w", err)
 	}
 
 	payload := StoreCreditPayload{}

--- a/vendor/github.com/vend/govend/vend/supplier.go
+++ b/vendor/github.com/vend/govend/vend/supplier.go
@@ -82,14 +82,15 @@ func (c Client) Pages(resource string, page int64) ([]SupplierBase, bool, int64,
 
 	body, err := c.MakeRequest("GET", url, nil)
 	if err != nil {
-		fmt.Printf("Error getting resource: %s", err)
+		err = fmt.Errorf("Error getting resource: %s", err)
+		return nil, false, 0, err
 	}
 
 	// Decode the raw JSON.
 	response := SupplierCollectionResponse{}
 	err = json.Unmarshal(body, &response)
 	if err != nil {
-		fmt.Printf("\nError unmarshalling payload: %s", err)
+		err = fmt.Errorf("Error unmarshalling payload: %w", err)
 		return nil, false, 0, err
 	}
 

--- a/vendor/github.com/vend/govend/vend/taxes.go
+++ b/vendor/github.com/vend/govend/vend/taxes.go
@@ -3,7 +3,7 @@ package vend
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 )
 
 // outletTaxes houses data from the /api/2.0/outlet_taxes endpoint
@@ -36,9 +36,13 @@ func (c *Client) Taxes() ([]Taxes, map[string]string, error) {
 	page := []Taxes{}
 
 	data, v, err := c.ResourcePage(0, "GET", "taxes")
+	if err != nil {
+		return taxes, nil, err
+	}
 	err = json.Unmarshal(data, &page)
 	if err != nil {
-		log.Printf("error while unmarshalling: %s", err)
+		err = fmt.Errorf("error while unmarshalling: %s", err)
+		return taxes, nil, err
 	}
 
 	taxes = append(taxes, page...)
@@ -46,7 +50,14 @@ func (c *Client) Taxes() ([]Taxes, map[string]string, error) {
 	for len(page) > 0 {
 		page = []Taxes{}
 		data, v, err = c.ResourcePage(v, "GET", "taxes")
+		if err != nil {
+			return taxes, nil, err
+		}
 		err = json.Unmarshal(data, &page)
+		if err != nil {
+			err = fmt.Errorf("error while unmarshalling: %s", err)
+			return taxes, nil, err
+		}
 		taxes = append(taxes, page...)
 
 	}
@@ -65,9 +76,13 @@ func (c *Client) OutletTaxes() ([]OutletTaxes, error) {
 	page := []OutletTaxes{}
 
 	data, v, err := c.ResourcePage(0, "GET", "outlet_taxes")
+	if err != nil {
+		return outletTaxes, err
+	}
 	err = json.Unmarshal(data, &page)
 	if err != nil {
-		log.Printf("error while unmarshalling: %s", err)
+		err = fmt.Errorf("error while unmarshalling: %s", err)
+		return outletTaxes, err
 	}
 
 	outletTaxes = append(outletTaxes, page...)
@@ -75,7 +90,14 @@ func (c *Client) OutletTaxes() ([]OutletTaxes, error) {
 	for len(page) > 0 {
 		page = []OutletTaxes{}
 		data, v, err = c.ResourcePage(v, "GET", "outlet_taxes")
+		if err != nil {
+			return outletTaxes, err
+		}
 		err = json.Unmarshal(data, &page)
+		if err != nil {
+			err = fmt.Errorf("error while unmarshalling: %s", err)
+			return outletTaxes, err
+		}
 		outletTaxes = append(outletTaxes, page...)
 
 	}

--- a/vendor/github.com/vend/govend/vend/user.go
+++ b/vendor/github.com/vend/govend/vend/user.go
@@ -3,6 +3,7 @@ package vend
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 )
 
@@ -34,7 +35,7 @@ func (c *Client) User() (User, error) {
 	data, _, err := c.ResourcePage(0, "GET", "user")
 	err = json.Unmarshal(data, &user)
 	if err != nil {
-		log.Printf("error while unmarshalling: %s", err)
+		err = fmt.Errorf("error while unmarshalling: %s", err)
 	}
 	return user, err
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -74,7 +74,7 @@ github.com/stretchr/testify/assert
 # github.com/subosito/gotenv v1.2.0
 ## explicit
 github.com/subosito/gotenv
-# github.com/vend/govend v0.4.1
+# github.com/vend/govend v0.5.0
 ## explicit
 github.com/vend/govend/vend
 # github.com/wallclockbuilder/stringutil v0.0.0-20151229105100-650d35b119a3


### PR DESCRIPTION
removes panic and print from govend, returning errors instead of panic. We'll need this for supportbot

improves exit method, introducing a notification package with a method ExitWithError. This will allow vendcli to have standardized exits instead differing styles in ecah command